### PR TITLE
backendのrepo名変更によるURL変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 ## バックエンド部
 
-[AMS_バックエンド](https://github.com/su-its/ams-backend-nodejs)
+[AMS_バックエンド](https://github.com/su-its/ams-backend)
 
 ---
 


### PR DESCRIPTION
- `-nodejs` がなくなったので変更に対応